### PR TITLE
Pull source from git instead of from (no longer available) archive

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,15 +14,15 @@ depends=('cty' 'fltk-git' 'libsamplerate' 'flxmlrpc>=1.0.1'
          'portaudio' 'libpulse' 'hamlib' 'hamradio-menus')
 optdepends=('libsndfile: sound file support'
             'pulseaudio: pulseaudio support')
-source=(http://w1hkj.com/files/$pkgname/$pkgname-$pkgver.tar.gz)
+source=(https://github.com/w1hkj/fldigi/archive/master.zip)
 
 prepare() {
-  patch --directory="$pkgname-$pkgver" --forward --strip=1 --input="${srcdir}/../hidpi-fix.patch"
+  patch --directory="$pkgname-master" --forward --strip=1 --input="${srcdir}/../hidpi-fix.patch"
 }
 
 build() {
-	cd "$srcdir"/$pkgname-$pkgver
-
+	cd "$srcdir"/$pkgname-master
+	autoreconf -fi
 	./configure --prefix=/usr \
 		--enable-tls --with-flxmlrpc --without-asciidoc
 #		--enable-tls --without-flxmlrpc --without-asciidoc
@@ -31,13 +31,13 @@ build() {
 }
 
 check() {
-	cd "$srcdir"/$pkgname-$pkgver
+	cd "$srcdir"/$pkgname-master
 
 	make -k check
 }
 
 package() {
-	cd "$srcdir"/$pkgname-$pkgver
+	cd "$srcdir"/$pkgname-master
 
 	make DESTDIR="$pkgdir" install
 }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This PKGBUILD for `makepkg` applies the HiDPI / 4K display scaling patch described here: https://groups.io/g/linuxham/message/47205
 
+This is a modification of [work by mmanjos](https://github.com/mmanjos/fldigi-pkgbuild-hidpi) to instead pull the latest fldigi source from git since the source package that repo used seems to be no longer available. I also increased the scale factor -- you can adjust the scale factor (currently `45.0`) in `hidpi-fix.patch` to adjust it more. (A smaller number means larger text/scale.)
+
 It needs to be built with fltk-1.4 or newer (currently in development)
 
 # Building and Installing on Arch Linux
@@ -10,8 +12,7 @@ Here's what worked for me:
 
 1. Build and install `fltk-git` from [AUR](https://aur.archlinux.org/packages/fltk-git)
 1. Clone this repo
-1. Run `makepkg` in the repo base directory (resolve any build dependencies, etc)
-1. Run `sudo pacman -U fldigi-4.1.22-2-x86_64.pkg.*` to install
+1. Run `makepkg -si --skipinteg` in the repo base directory (resolve any build dependencies, etc) to build and install
 
 # What it changes
 

--- a/hidpi-fix.patch
+++ b/hidpi-fix.patch
@@ -10,7 +10,7 @@
 +
 +std::cout << "current screen scale factor: " << Fl::screen_scale(0) << std::endl;
 +
-+float scrn_scale = dpx / 90.0;
++float scrn_scale = dpx / 45.0;
 +
 +std::cout << "new screen scale factor: " << scrn_scale << std::endl;
 +    Fl::screen_scale(0, scrn_scale);


### PR DESCRIPTION
Existing PKGBUILD doesn't work because the linked archive 403s. This works for me.

Thanks for the initial PKGBUILD -- made my first PSK31 QSO today :).